### PR TITLE
Hop and yeast error detection and correction

### DIFF
--- a/Sources/HopScraper.py
+++ b/Sources/HopScraper.py
@@ -566,9 +566,9 @@ class HopScraper(BaseScraper[Hop]) :
             td_node : bs4.Tag = parent_node.find("td") #type: ignore
             if content == required[0] :
                 a_node = td_node.find("a")
-                purpose = a_node.contents[0].text #type: ignore
+                purpose : str = a_node.contents[0].text #type: ignore
                 if purpose != "" :
-                    txt = self.format_text(purpose)
+                    txt = self.format_text(purpose) #type: ignore
                     hop.purpose = hop_attribute_from_str(txt)
                 else :
                     hop.add_parsing_error("Empty data for Hop Purpose")

--- a/Sources/Main.py
+++ b/Sources/Main.py
@@ -390,14 +390,20 @@ def main(args : list[str]):
         for i in range(0, len(yeast.comparable_yeasts)):
             # Data originally contains a link that points to the substitute hop,
             # we'll change that for its UUID instead, which is closer to what we'll find in a regular database
-            linked_yeast = yeast.comparable_yeasts[i]
-            target = [item for item in yeasts if item.link == linked_yeast]
+            linked_yeast_name = yeast.comparable_yeasts[i]
+
+            target_link = [item for item in categorized_links.yeasts if linked_yeast_name.lower() in item]
+            if len(target_link) == 0:
+                print(f"Yeast : \"{yeast.name}\" with link : {yeast.link} has issues in comparable yeasts : \"{linked_yeast_name}\"")
+                continue
+
+            target = [item for item in yeasts if item.link == target_link[0]]
             if len(target) != 0 :
                 yeast.comparable_yeasts[i] = target[0].id
             else :
                 # We are stumbling on "bad" links : for some linked yeasts, there are issues with the website api calls and redirection did not work
                 # So we'll need to find a solution for that.
-                print(f"Yeast : \"{yeast.name}\" with link : {yeast.link} has issues in comparable yeasts : \"{linked_yeast}\"")
+                print(f"Yeast : \"{yeast.name}\" with link : {yeast.link} has issues in comparable yeasts : \"{linked_yeast_name}\"")
 
     print("Dumping post-processed yeasts to disk.")
     write_yeasts_json_to_disk(Directories.PROCESSED_DIR.joinpath("yeasts.json"), yeasts)

--- a/Sources/Main.py
+++ b/Sources/Main.py
@@ -386,6 +386,18 @@ def main(args : list[str]):
         if yeast.id == "" :
             yeast.id = str(uuid.uuid4())
 
+
+    print("Reading yeasts corrections files before yeast post-processing")
+    this_dir = Path(__file__).parent
+    yeast_correction_filepath = this_dir.joinpath("yeasts_corrections.json")
+    yeast_corrections : dict[str, Any] = {}
+    with open(yeast_correction_filepath, 'r') as file :
+        yeast_corrections = json.load(file)
+
+    # Redo that step as the yeasts and hops links were popped out (because of how the reference system works)
+    categorized_links = split_links_by_category(links)
+
+
     for yeast in yeasts :
         for i in range(0, len(yeast.comparable_yeasts)):
             # Data originally contains a link that points to the substitute hop,
@@ -394,8 +406,13 @@ def main(args : list[str]):
 
             target_link = [item for item in categorized_links.yeasts if linked_yeast_name.lower() in item]
             if len(target_link) == 0:
-                print(f"Yeast : \"{yeast.name}\" with link : {yeast.link} has issues in comparable yeasts : \"{linked_yeast_name}\"")
-                continue
+                # Use yeasts corrections patch file now !
+                correction = [x["link"] for x in yeast_corrections["yeasts"] if x["alias"] == linked_yeast_name]
+                if len(correction) == 0 or correction[0] == None :
+                    print(f"Yeast : \"{yeast.name}\" with link : {yeast.link} has issues in comparable yeasts : \"{linked_yeast_name}\"")
+                    continue
+                target_link = correction
+                print(f"Yeast : \"{yeast.name}\" referenced yeast was fixed for reference : \"{linked_yeast_name}\"")
 
             target = [item for item in yeasts if item.link == target_link[0]]
             if len(target) != 0 :

--- a/Sources/Models/Hop.py
+++ b/Sources/Models/Hop.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 from dataclasses import field, dataclass
-from typing import cast, Any
+from typing import Optional, cast, Any
 
 from .Ranges import RatioRange, NumericRange
 from .ScapedObject import ScrapedObject
@@ -70,30 +70,30 @@ class RadarChart(Jsonable) :
 @dataclass
 class Hop(ScrapedObject) :
     # Basic characteristics
-    name : str                  = field(default_factory=str)
-    link : str                  = field(default_factory=str)
-    purpose : HopAttribute      = HopAttribute.Bittering
-    country : str               = field(default_factory=str)
-    international_code : str    = field(default_factory=str)
-    cultivar_id : str           = field(default_factory=str)
-    origin_txt : str            = field(default_factory=str)
-    flavor_txt : str            = field(default_factory=str)
-    tags : list[str]            = field(default_factory=list)
+    name :                  str            = field(default_factory=str)
+    link :                  str            = field(default_factory=str)
+    purpose :               HopAttribute   = HopAttribute.Bittering
+    country :               Optional[str]  = field(default=None)
+    international_code :    Optional[str]  = field(default=None)
+    cultivar_id :           Optional[str]  = field(default=None)
+    origin_txt :            str            = field(default_factory=str)
+    flavor_txt :            str            = field(default_factory=str)
+    tags :                  list[str]      = field(default_factory=list)
 
     # Hop detailed characteristics
-    alpha_acids : NumericRange              = field(default_factory=NumericRange)
-    beta_acids : NumericRange               = field(default_factory=NumericRange)
-    alpha_beta_ratio : RatioRange           = field(default_factory=RatioRange)
-    hop_storage_index : float               = 100
-    co_humulone_normalized : NumericRange   = field(default_factory=NumericRange)
-    total_oils : NumericRange               = field(default_factory=NumericRange)
+    alpha_acids :               Optional[NumericRange]  = field(default=None)
+    beta_acids :                Optional[NumericRange]  = field(default=None)
+    alpha_beta_ratio :          Optional[RatioRange]    = field(default=None)
+    hop_storage_index :         Optional[float]         = field(default=None)
+    co_humulone_normalized :    Optional[NumericRange]  = field(default=None)
+    total_oils :                Optional[NumericRange]  = field(default=None)
 
     # Oil contents
-    myrcene : NumericRange          = field(default_factory=NumericRange)
-    humulene : NumericRange         = field(default_factory=NumericRange)
-    caryophyllene : NumericRange    = field(default_factory=NumericRange)
-    farnesene : NumericRange        = field(default_factory=NumericRange)
-    other_oils : NumericRange       = field(default_factory=NumericRange)
+    myrcene :       Optional[NumericRange]  = field(default=None)
+    humulene :      Optional[NumericRange]  = field(default=None)
+    caryophyllene : Optional[NumericRange]  = field(default=None)
+    farnesene :     Optional[NumericRange]  = field(default=None)
+    other_oils :    Optional[NumericRange]  = field(default=None)
 
     # Textual description of beer styles, this is written in length text.
     # Assuming the populating data comes from an Api of some sort, we can probably identify a pattern and remove it programmatically to
@@ -104,7 +104,7 @@ class Hop(ScrapedObject) :
     # For now this will do, especially if there is no name conflict.
     substitutes : list[str] = field(default_factory=list)
 
-    radar_chart : RadarChart = field(default_factory=RadarChart)
+    radar_chart : Optional[RadarChart] = field(default=None)
 
     def __eq__(self, other: object) -> bool:
 
@@ -153,20 +153,20 @@ class Hop(ScrapedObject) :
             "originTxt" : self.origin_txt,
             "flavorTxt" : self.flavor_txt,
             "tags" : self.tags,
-            "alphaAcids" : self.alpha_acids.to_json(),
-            "betaAcids" : self.beta_acids.to_json(),
-            "alphaBetaRatio" : self.alpha_beta_ratio.to_json(),
+            "alphaAcids" : self.alpha_acids.to_json() if self.alpha_acids else None,
+            "betaAcids" : self.beta_acids.to_json() if self.beta_acids else None,
+            "alphaBetaRatio" : self.alpha_beta_ratio.to_json() if self.alpha_beta_ratio else None,
             "hopStorageIndex" : self.hop_storage_index,
-            "coHumuloneNormalized" : self.co_humulone_normalized.to_json(),
-            "totalOils" : self.total_oils.to_json(),
-            "myrcene" : self.myrcene.to_json(),
-            "humulene" : self.humulene.to_json(),
-            "caryophyllene"  : self.caryophyllene.to_json(),
-            "farnesene" : self.farnesene.to_json(),
-            "otherOils" : self.other_oils.to_json(),
+            "coHumuloneNormalized" : self.co_humulone_normalized.to_json() if self.co_humulone_normalized else None,
+            "totalOils" : self.total_oils.to_json() if self.total_oils else None,
+            "myrcene" : self.myrcene.to_json() if self.myrcene else None,
+            "humulene" : self.humulene.to_json() if self.humulene else None,
+            "caryophyllene"  : self.caryophyllene.to_json() if self.caryophyllene else None,
+            "farnesene" : self.farnesene.to_json() if self.farnesene else None,
+            "otherOils" : self.other_oils.to_json() if self.other_oils else None,
             "beerStyles" : self.beer_styles,
             "substitutes" : self.substitutes,
-            "radarChart" : self.radar_chart.to_json()
+            "radarChart" : self.radar_chart.to_json() if self.radar_chart else None
         }
 
         # Doing the parent at the end as it only contains the parsingErrors that we want to go to the end of the object
@@ -186,23 +186,72 @@ class Hop(ScrapedObject) :
         self.origin_txt = self._read_prop("originTxt", content, "")
         self.flavor_txt = self._read_prop("flavorTxt", content, "")
         self.tags = self._read_prop("tags", content, "")
-        self.alpha_acids.from_json(content["alphaAcids"])
-        self.beta_acids.from_json(content["betaAcids"])
-        self.alpha_beta_ratio.from_json(content["alphaBetaRatio"])
+
+        if "alphaAcids" in content :
+            self.alpha_acids = NumericRange()
+            self.alpha_acids.from_json(content["alphaAcids"])
+
+        if "betaAcids" in content :
+            self.beta_acids = NumericRange()
+            self.beta_acids.from_json(content["betaAcids"])
+
+        if "alphaBetaRatio" in content :
+            self.alpha_beta_ratio = RatioRange()
+            self.alpha_beta_ratio.from_json(content["alphaBetaRatio"])
+
         self.hop_storage_index = self._read_prop("hopStorageIndex", content, 80)
-        self.co_humulone_normalized.from_json(content["coHumuloneNormalized"])
-        self.total_oils.from_json(content["totalOils"])
-        self.myrcene.from_json(content["myrcene"])
-        self.humulene.from_json(content["humulene"])
-        self.caryophyllene.from_json(content["caryophyllene"])
-        self.farnesene.from_json(content["farnesene"])
-        self.other_oils.from_json(content["otherOils"])
+
+        if "coHumuloneNormalized" :
+            self.co_humulone_normalized = NumericRange()
+            self.co_humulone_normalized.from_json(content["coHumuloneNormalized"])
+
+        if "totalOils" in content :
+            self.total_oils = NumericRange()
+            self.total_oils.from_json(content["totalOils"])
+
+        if "myrcene" in content :
+            self.myrcene = NumericRange()
+            self.myrcene.from_json(content["myrcene"])
+
+        if "humulene" in content :
+            self.humulene = NumericRange()
+            self.humulene.from_json(content["humulene"])
+
+        if "caryophyllene" in content:
+            self.caryophyllene = NumericRange()
+            self.caryophyllene.from_json(content["caryophyllene"])
+
+        if "farnesene" in content:
+            self.farnesene = NumericRange()
+            self.farnesene.from_json(content["farnesene"])
+
+        if "otherOils" in content :
+            self.other_oils = NumericRange()
+            self.other_oils.from_json(content["otherOils"])
         self.beer_styles = self._read_prop("beerStyles", content, [])
         self.substitutes = self._read_prop("substitutes", content, [])
 
-        self.radar_chart.from_json(content["radarChart"])
+        if "radarChart" in  content :
+            self.radar_chart = RadarChart()
+            self.radar_chart.from_json(content["radarChart"])
 
     def radar_chart_from_bmapi(self, api_model : bmapi.BMHopModel) :
+        """Converts the radar chart from the api into an internal model and scan for all zeros.
+           In case incoming data only contains zeros, it means that data is lacking the radar chart values and we can reject it."""
+        empty = True
+        for item in api_model.primary.radar_chart:
+            if item != 0 :
+                empty = False
+                break
+        # Empty data model won't be usable later on
+        # So check for all zeros, and if so it means we are lacking data.
+        # It'll be easier for consumer code to tell it's missing data and we can't redraw the radar chart.
+        if empty :
+            self.add_parsing_error("No data for radar chart")
+            return
+
+        if self.radar_chart == None :
+            self.radar_chart = RadarChart()
         self.radar_chart.citrus = api_model.primary.radar_chart[0]
         self.radar_chart.tropical_fruit = api_model.primary.radar_chart[1]
         self.radar_chart.stone_fruit = api_model.primary.radar_chart[2]
@@ -212,6 +261,3 @@ class Hop(ScrapedObject) :
         self.radar_chart.herbal = api_model.primary.radar_chart[6]
         self.radar_chart.spice = api_model.primary.radar_chart[7]
         self.radar_chart.resinous = api_model.primary.radar_chart[8]
-
-
-        # Some text

--- a/Sources/Models/Hop.py
+++ b/Sources/Models/Hop.py
@@ -108,9 +108,9 @@ class Hop(ScrapedObject) :
     radar_chart : Optional[RadarChart] = field(default=None)
 
     def __eq__(self, other: object) -> bool:
-
         if type(self) != type(other) :
             return False
+
         other = cast(Hop, other)
         self = cast(Hop, self)
         identical = True

--- a/Sources/Models/Hop.py
+++ b/Sources/Models/Hop.py
@@ -20,7 +20,7 @@ def hop_attribute_from_str(input : str) -> HopAttribute :
         case HopAttribute.Bittering.value :
             return HopAttribute.Bittering
 
-        case HopAttribute.Aromatic.value :
+        case HopAttribute.Aromatic.value | "Aroma":
             return HopAttribute.Aromatic
 
         case HopAttribute.Hybrid.value | "Dual" :
@@ -76,6 +76,7 @@ class Hop(ScrapedObject) :
     country :               Optional[str]  = field(default=None)
     international_code :    Optional[str]  = field(default=None)
     cultivar_id :           Optional[str]  = field(default=None)
+    ownership:              Optional[str]  = field(default=None)
     origin_txt :            str            = field(default_factory=str)
     flavor_txt :            str            = field(default_factory=str)
     tags :                  list[str]      = field(default_factory=list)
@@ -120,6 +121,7 @@ class Hop(ScrapedObject) :
         identical &= self.purpose == other.purpose
         identical &= self.country == other.country
         identical &= self.international_code == other.international_code
+        identical &= self.ownership == other.ownership
         identical &= self.cultivar_id == other.cultivar_id
         identical &= self.origin_txt == other.origin_txt
         identical &= self.flavor_txt == other.flavor_txt
@@ -149,6 +151,7 @@ class Hop(ScrapedObject) :
             "purpose" : self.purpose.value,
             "country" : self.country,
             "internationalCode" : self.international_code,
+            "ownership" : self.ownership,
             "cultivarId" : self.cultivar_id,
             "originTxt" : self.origin_txt,
             "flavorTxt" : self.flavor_txt,
@@ -179,10 +182,14 @@ class Hop(ScrapedObject) :
         self.name = self._read_prop("name", content, "")
         self.id = self._read_prop("id", content, "")
         self.link = self._read_prop("link", content, "")
-        self.purpose = hop_attribute_from_str(self._read_prop("purpose", content, ""))
-        self.country = self._read_prop("country", content, "")
-        self.international_code = self._read_prop("internationalCode", content, "")
-        self.cultivar_id = self._read_prop("cultivarId", content, "")
+        self.purpose = hop_attribute_from_str(self._read_prop("purpose", content, HopAttribute.Bittering))
+
+        # Optionals, direct read either return a value or None, so we're good with this
+        self.country = content["country"]
+        self.international_code = content["internationalCode"]
+        self.cultivar_id = content["cultivarId"]
+        self.ownership = content["ownership"]
+
         self.origin_txt = self._read_prop("originTxt", content, "")
         self.flavor_txt = self._read_prop("flavorTxt", content, "")
         self.tags = self._read_prop("tags", content, "")

--- a/Sources/Models/Hop.py
+++ b/Sources/Models/Hop.py
@@ -176,6 +176,26 @@ class Hop(ScrapedObject) :
         content.update(super().to_json())
         return content
 
+    def parse_numeric_range(self, key : str, content : dict[str, Any]) -> Optional[NumericRange]:
+        try :
+            if key in content and content[key] != None:
+                data = NumericRange()
+                data.from_json(content[key])
+                return data
+        except :
+            return None
+        return None
+
+    def parse_ratio_range(self, key : str, content : dict[str, Any]) -> Optional[RatioRange]:
+        try :
+            if key in content and content[key] != None:
+                data = RatioRange()
+                data.from_json(content[key])
+                return data
+        except :
+            return None
+        return None
+
     def from_json(self, content : dict[str, Any]) -> None :
         super().from_json(content)
 
@@ -194,53 +214,26 @@ class Hop(ScrapedObject) :
         self.flavor_txt = self._read_prop("flavorTxt", content, "")
         self.tags = self._read_prop("tags", content, "")
 
-        if "alphaAcids" in content :
-            self.alpha_acids = NumericRange()
-            self.alpha_acids.from_json(content["alphaAcids"])
-
-        if "betaAcids" in content :
-            self.beta_acids = NumericRange()
-            self.beta_acids.from_json(content["betaAcids"])
-
-        if "alphaBetaRatio" in content :
-            self.alpha_beta_ratio = RatioRange()
-            self.alpha_beta_ratio.from_json(content["alphaBetaRatio"])
+        self.alpha_acids = self.parse_numeric_range("alphaAcids", content)
+        self.beta_acids = self.parse_numeric_range("betaAcids", content)
+        self.alpha_beta_ratio = self.parse_ratio_range("alphaBetaRatio", content)
 
         self.hop_storage_index = self._read_prop("hopStorageIndex", content, 80)
+        self.co_humulone_normalized = self.parse_numeric_range("coHumuloneNormalized", content)
+        self.total_oils = self.parse_numeric_range("totalOils", content)
+        self.myrcene = self.parse_numeric_range("myrcene", content)
+        self.humulene = self.parse_numeric_range("humulene", content)
+        self.caryophyllene = self.parse_numeric_range("caryophyllene", content)
+        self.farnesene = self.parse_numeric_range("farnesene", content)
+        self.other_oils = self.parse_numeric_range("otherOils", content)
 
-        if "coHumuloneNormalized" :
-            self.co_humulone_normalized = NumericRange()
-            self.co_humulone_normalized.from_json(content["coHumuloneNormalized"])
-
-        if "totalOils" in content :
-            self.total_oils = NumericRange()
-            self.total_oils.from_json(content["totalOils"])
-
-        if "myrcene" in content :
-            self.myrcene = NumericRange()
-            self.myrcene.from_json(content["myrcene"])
-
-        if "humulene" in content :
-            self.humulene = NumericRange()
-            self.humulene.from_json(content["humulene"])
-
-        if "caryophyllene" in content:
-            self.caryophyllene = NumericRange()
-            self.caryophyllene.from_json(content["caryophyllene"])
-
-        if "farnesene" in content:
-            self.farnesene = NumericRange()
-            self.farnesene.from_json(content["farnesene"])
-
-        if "otherOils" in content :
-            self.other_oils = NumericRange()
-            self.other_oils.from_json(content["otherOils"])
         self.beer_styles = self._read_prop("beerStyles", content, [])
         self.substitutes = self._read_prop("substitutes", content, [])
 
-        if "radarChart" in  content :
+        radar_chart_key = "radarChart"
+        if radar_chart_key in content and content[radar_chart_key] != None:
             self.radar_chart = RadarChart()
-            self.radar_chart.from_json(content["radarChart"])
+            self.radar_chart.from_json(content[radar_chart_key])
 
     def radar_chart_from_bmapi(self, api_model : bmapi.BMHopModel) :
         """Converts the radar chart from the api into an internal model and scan for all zeros.

--- a/Sources/Models/Hop.py
+++ b/Sources/Models/Hop.py
@@ -176,16 +176,6 @@ class Hop(ScrapedObject) :
         content.update(super().to_json())
         return content
 
-    def parse_numeric_range(self, key : str, content : dict[str, Any]) -> Optional[NumericRange]:
-        try :
-            if key in content and content[key] != None:
-                data = NumericRange()
-                data.from_json(content[key])
-                return data
-        except :
-            return None
-        return None
-
     def parse_ratio_range(self, key : str, content : dict[str, Any]) -> Optional[RatioRange]:
         try :
             if key in content and content[key] != None:

--- a/Sources/Models/ScapedObject.py
+++ b/Sources/Models/ScapedObject.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Any, Optional, cast
+
+from Sources.Models.Ranges import NumericRange
 from .Jsonable import Jsonable
 
 @dataclass
@@ -22,6 +24,16 @@ class ScrapedObject(Jsonable) :
             self.parsing_errors = []
 
         self.parsing_errors.append(message)
+
+    def parse_numeric_range(self, key : str, content : dict[str, Any]) -> Optional[NumericRange]:
+        try :
+            if key in content and content[key] != None:
+                data = NumericRange()
+                data.from_json(content[key])
+                return data
+        except :
+            return None
+        return None
 
     def __eq__(self, other: object) -> bool:
         other = cast(ScrapedObject,other)

--- a/Sources/Models/Tests/test_hop_serialization.py
+++ b/Sources/Models/Tests/test_hop_serialization.py
@@ -9,6 +9,7 @@ class TestHopModelSerialization(unittest.TestCase):
         hop.name = "Test hop"
         hop.link = "https://beermaverick.com/hop/apollo/"
         hop.purpose = HopAttribute.Aromatic
+        hop.ownership = "Someone"
         hop.country = "don't know"
         hop.international_code = "maybe"
         hop.cultivar_id = "perhaps"

--- a/Sources/Models/Tests/test_hop_serialization.py
+++ b/Sources/Models/Tests/test_hop_serialization.py
@@ -1,6 +1,7 @@
 import unittest
 import json
 from ..Hop import Hop, HopAttribute, RadarChart
+from ..Ranges import NumericRange, RatioRange
 
 class TestHopModelSerialization(unittest.TestCase):
     def test_hop_symmetric_json(self):
@@ -15,34 +16,45 @@ class TestHopModelSerialization(unittest.TestCase):
         hop.flavor_txt = "some flavor"
         hop.tags = ["tag1", "tag2", "tag3"]
 
+        hop.alpha_acids = NumericRange()
         hop.alpha_acids.max.value = 3
         hop.alpha_acids.min.value = 2
 
+        hop.beta_acids = NumericRange()
         hop.beta_acids.max.value = 4
         hop.beta_acids.min.value = 5
 
+        hop.alpha_beta_ratio = RatioRange()
         hop.alpha_beta_ratio.max.value = "3:2"
         hop.alpha_beta_ratio.min.value = "2:1"
 
         hop.hop_storage_index = 85
+
+        hop.co_humulone_normalized = NumericRange()
         hop.co_humulone_normalized.max.value = 66
         hop.co_humulone_normalized.min.value = 99
 
+        hop.total_oils = NumericRange()
         hop.total_oils.max.value = 1
         hop.total_oils.min.value = 2
 
+        hop.myrcene = NumericRange()
         hop.myrcene.max.value = 3
         hop.myrcene.min.value = 4
 
+        hop.humulene = NumericRange()
         hop.humulene.max.value = 5
         hop.humulene.min.value = 6
 
+        hop.caryophyllene = NumericRange()
         hop.caryophyllene.max.value = 7
         hop.caryophyllene.min.value = 8
 
+        hop.farnesene = NumericRange()
         hop.farnesene.max.value = 9
         hop.farnesene.min.value = 10
 
+        hop.other_oils = NumericRange()
         hop.other_oils.max.value = 11
         hop.other_oils.min.value = 12
 

--- a/Sources/Models/Tests/test_yeast_serialization.py
+++ b/Sources/Models/Tests/test_yeast_serialization.py
@@ -1,0 +1,35 @@
+import unittest
+import json
+from ..Yeast import Yeast, Packaging, Flocculation
+from ..Ranges import NumericRange
+
+class TestYeastModelSerialization(unittest.TestCase):
+    def test_yeast_symmetric_json(self):
+        yeast = Yeast()
+        yeast.name = "Test yeast"
+        yeast.link = "https://beermaverick.com/yeast/apollo/"
+        yeast.brand = "some brand"
+        yeast.type = "Yeast"
+        yeast.packaging = Packaging.Dry
+        yeast.has_bacterias = False
+        yeast.species = ["Saccharomyces cerevisiae"]
+        yeast.description = "A very good yeast"
+        yeast.tags = ["Tag1", "Tag2", "Tag3"]
+        yeast.alcohol_tolerance = 12
+        yeast.attenuation = NumericRange(70,80)
+        yeast.flocculation = Flocculation.High
+        yeast.optimal_temperature = NumericRange(16,23)
+        yeast.comparable_yeasts = ["yeast1", "yeast2"]
+        yeast.common_beer_styles = ["Pale Ale", "Funky style"]
+
+
+        content = yeast.to_json()
+        print(json.dumps(content, indent=4))
+        parsed_object = Yeast()
+        parsed_object.from_json(content)
+
+        # Data is good but we need a custom comparator
+        self.assertEqual(yeast, parsed_object)
+
+if __name__ == "__main__" :
+    unittest.main()

--- a/Sources/Models/Yeast.py
+++ b/Sources/Models/Yeast.py
@@ -92,18 +92,12 @@ class Yeast(ScrapedObject):
         for item in content["tags"] :
             self.tags.append(item)
 
-        self.alcohol_tolerance = content["alcoholTolerance"]
-
-        if "attenuation" in content :
-            self.attenuation = NumericRange()
-            self.attenuation.from_json(content["attenuation"])
-
+        if "alcoholTolerance" in content and content["alcoholTolerance"]:
+            self.alcohol_tolerance = float(content["alcoholTolerance"])
+        self.attenuation = self.parse_numeric_range("attenuation", content)
         self.flocculation = str_to_flocculation(content["flocculation"])
 
-        if "optimalTemperature" in content :
-            self.optimal_temperature = NumericRange()
-            self.optimal_temperature.from_json(content["optimalTemperature"])
-
+        self.optimal_temperature = self.parse_numeric_range("optimalTemperature", content)
         self.comparable_yeasts = []
         for item in content["comparableYeasts"] :
             self.comparable_yeasts.append(item)

--- a/Sources/Models/Yeast.py
+++ b/Sources/Models/Yeast.py
@@ -24,6 +24,7 @@ def str_to_flocculation(input : Optional[str]) -> Flocculation:
     data = [
         Flocculation.VeryLow,
         Flocculation.Low,
+        Flocculation.LowMedium,
         Flocculation.Medium,
         Flocculation.MediumHigh,
         Flocculation.High,
@@ -33,6 +34,10 @@ def str_to_flocculation(input : Optional[str]) -> Flocculation:
         if input.lower() == item.value.lower() :
             return item
 
+    # Some yeast has the "Medium-Low" tag, which is more or less "Low-Medium" in reverse (...).
+    # Dedicated corner case parsing here :)
+    if Flocculation.Medium.value.lower() in input.lower() and Flocculation.Low.value.lower() in input.lower():
+        return Flocculation.LowMedium
     return Flocculation.Unknown
 
 class Packaging(Enum) :

--- a/Sources/YeastScraper.py
+++ b/Sources/YeastScraper.py
@@ -10,7 +10,7 @@ from threading import Thread
 import bs4
 
 from .BaseScraper import BaseScraper, ItemPair
-from .Models.Yeast import Yeast
+from .Models.Yeast import Yeast, Flocculation, str_to_flocculation, str_to_packaging
 from .Models.Ranges import NumericRange
 from .Utils import parallel
 
@@ -382,27 +382,32 @@ class YeastScraper(BaseScraper[Yeast]) :
             return None
         return header[0]
 
-    def parse_numeric_range(self, node : bs4.Tag, range : NumericRange, unit_char : str = "%") -> bool :
+    def parse_numeric_range(self, node : bs4.Tag, unit_char : str = "%") -> Optional[NumericRange]  :
         values = node.contents[0].text.rstrip(unit_char).split("-")
 
         if len(values) < 1 or len(values) > 2:
-            return False
+            return None
+
+        min = 0
+        max = 0
 
         try :
             if len(values) == 1 :
-                range.min.value = float(values[0].strip())
-                range.max.value = range.min.value
+                min = float(values[0].strip())
+                max = min
             if len(values) == 2 :
-                range.min.value = float(values[0].strip())
-                range.max.value = float(values[1].strip())
+                min = float(values[0].strip())
+                max = float(values[1].strip())
         # Might fail if one of the values is not convertible to float (happens with some default values)
         # In some cases, numerical values are replaced by the "Unknown" keyword, which makes parsing more difficult
         except :
-            return False
-        return True
+            return None
 
-    def parse_percentage_value(self, td : bs4.Tag, range : NumericRange) -> bool :
-        return self.parse_numeric_range(td, range, "%")
+        range = NumericRange(min, max)
+        return range
+
+    def parse_percentage_value(self, td : bs4.Tag) -> Optional[NumericRange] :
+        return self.parse_numeric_range(td, "%")
 
     def farenheit_to_degrees(self, farenheit : float) -> float :
         return (farenheit - 32) * 5/9
@@ -443,18 +448,27 @@ class YeastScraper(BaseScraper[Yeast]) :
                 if "Unknown" == value :
                     yeast.add_parsing_error("No available values for attenuation.")
                 else :
-                    if not self.parse_percentage_value(value_node, yeast.attenuation):
+                    yeast.attenuation = self.parse_percentage_value(value_node)
+                    if not yeast.attenuation:
                         error_list.append("Caught unexpected content for attenutation")
 
             elif "Flocculation" in text:
-                yeast.flocculation = value_node.text
+                yeast.flocculation = str_to_flocculation(value_node.text)
 
             elif "Optimal Temperature" in text:
-                if not self.parse_numeric_range(value_node, yeast.optimal_temperature, "° F") :
+                yeast.optimal_temperature = self.parse_numeric_range(value_node, "° F")
+                if not yeast.optimal_temperature:
                     error_list.append("Caught unexpected content for optimal temperatures")
                     continue
                 yeast.optimal_temperature.max.value = round(self.farenheit_to_degrees(yeast.optimal_temperature.max.value))
                 yeast.optimal_temperature.min.value = round(self.farenheit_to_degrees(yeast.optimal_temperature.min.value))
+
+        if not yeast.attenuation :
+            yeast.add_parsing_error("No data for Attenuation")
+        if not yeast.optimal_temperature :
+            yeast.add_parsing_error("No data for Optimal Temperature")
+        if yeast.flocculation == Flocculation.Unknown:
+            yeast.add_parsing_error("No data for Flocculation")
 
         return True
 
@@ -507,13 +521,25 @@ class YeastScraper(BaseScraper[Yeast]) :
             parent_node = th.parent
             td_node : bs4.Tag = parent_node.find("td") #type: ignore
             if content == "Brand:" :
-                yeast.brand = self.format_text(td_node.contents[0].text)
+                brand = self.format_text(td_node.contents[0].text)
+                if brand != "" :
+                    yeast.brand = brand
+                else :
+                    yeast.add_parsing_error("Empty data for Brand")
 
             elif content == "Type:" :
-                yeast.type = self.format_text(td_node.contents[0].text)
+                type = self.format_text(td_node.contents[0].text)
+                if type != "" :
+                    yeast.type = type
+                else :
+                    yeast.add_parsing_error("Empty data for Type")
 
             elif content == "Packet:" :
-                yeast.packaging = self.format_text(td_node.contents[0].text)
+                package = self.format_text(td_node.contents[0].text)
+                if package != "" :
+                    yeast.packaging = str_to_packaging(package)
+                else :
+                    yeast.add_parsing_error("Empty data for Packet")
 
             elif content == "Species:" :
                 yeast.species = []

--- a/Sources/yeasts_corrections.json
+++ b/Sources/yeasts_corrections.json
@@ -1,0 +1,139 @@
+{
+    "yeasts" :
+    [
+        {
+            "alias" : "ES-FOG",
+            "comment" :"codename not in link",
+            "link" : "https://beermaverick.com/yeast/foggy-london-ale-escarpment-labs/"
+        },
+        {
+            "alias" : "WY1068",
+            "comment" : "typo in the website",
+            "link" : "https://beermaverick.com/yeast/wy1968-london-esb-ale-wyeast/"
+        },
+        {
+            "alias" : "LAL-VERDANT",
+            "link" : "https://beermaverick.com/yeast/lallemand-lalbrew-verdant-ipa/"
+        },
+        {
+            "alias" : "B63",
+            "comment" : "whole in database",
+            "link" : "https://www.brewersfriend.com/yeasts/imperial-yeast-b63-monastic/"
+        },
+        {
+            "alias" : "LB_NE",
+            "comment" : "codename not in link",
+            "link" : "https://beermaverick.com/yeast/lalbrew-new-england-lallemand/"
+        },
+        {
+            "alias" : "GY107",
+            "comment" : "unknown yeast",
+            "link" : null
+        },
+        {
+            "alias" : "W-34/70",
+            "comment" : "codename not in link",
+            "link" : "https://beermaverick.com/yeast/w-34-70-saflager-w-34-70-fermentis/"
+        },
+        {
+            "alias" : "Lallemand Belle Saison",
+            "comment" : "codename not in link",
+            "link" : "https://beermaverick.com/yeast/lalbrew-belle-saison-lallemand/"
+        },
+        {
+            "alias" : "ECY29",
+            "comment" : "codename not in link",
+            "link" : "https://beermaverick.com/yeast/ecy029-north-east-ale-east-coast-yeast/"
+        },
+        {
+            "alias" : "ES-VT",
+            "comment" : "codename not in link",
+            "link" : "https://beermaverick.com/yeast/vermont-ale-escarpment-labs/"
+        },
+        {
+            "alias" : "WLP6860",
+            "comment" : "whole in database",
+            "link" : "https://www.whitelabs.com/yeast-single?id=230&type=YEAST"
+        },
+        {
+            "alias" : "Lalbrew Nottingham",
+            "comment" : "codename not in link",
+            "link" : "https://beermaverick.com/yeast/lalbrew-nottingham-lallemand/"
+        },
+        {
+            "alias" : "WLP025",
+            "comment" : "whole in database",
+            "link" : "https://www.whitelabs.com/yeast-single?id=116&style_type=0&type=YEAST"
+        },
+        {
+            "alias" : "WLP720",
+            "comment" : "whole in database",
+            "link" : "https://www.whitelabs.com/yeast-single?id=206&style_type=3&type=YEAST"
+        },
+        {
+            "alias" : "WY2450",
+            "comment" : "typo in the website",
+            "link" : "https://beermaverick.com/yeast/wy1450-dennys-favorite-50-ale-wyeast/"
+        },
+        {
+            "alias" : "WLP003",
+            "comment" : "whole in database",
+            "link" : "https://www.whitelabs.com/yeast-single?id=103&style_type=0&type=YEAST"
+        },
+        {
+            "alias" : "WLP515",
+            "comment" : "whole in database",
+            "link" : "https://www.whitelabs.com/yeast-single?id=156&style_type=5&type=YEAST"
+        },
+        {
+            "alias" : "Lallebrew Voss",
+            "comment" : "codename not in link",
+            "link" : "https://beermaverick.com/yeast/lalbrew-voss-lallemand/"
+        },
+        {
+            "alias" : "WLP650",
+            "comment" : "whole in database",
+            "link" : "https://www.whitelabs.com/yeast-single?id=185&style_type=7&type=YEAST"
+        },
+        {
+            "alias" : "WY2484",
+            "comment" : "doesn't exist",
+            "link" : null
+        },
+        {
+            "alias" : "WLP885",
+            "comment" : "whole in database",
+            "link" : "https://www.whitelabs.com/yeast-single?id=231&style_type=2&type=YEAST"
+        },
+        {
+            "alias" : "WL2124",
+            "comment" : "doesn't exist",
+            "link" : null
+        },
+        {
+            "alias" : "Lallemand Windsor",
+            "comment" : "codename not in link",
+            "link" : "https://beermaverick.com/yeast/lalbrew-windsor-lallemand/"
+        },
+        {
+            "alias" : "M31",
+            "comment" : "whole in database",
+            "link" : "https://mangrovejacks.com/products/belgian-tripel-m31-yeast-10g"
+        },
+        {
+            "alias" : "B51",
+            "comment" : "whole in database",
+            "link" : "https://www.brewersfriend.com/yeasts/imperial-yeast-b51-workhorse/"
+        },
+        {
+            "alias" : "Lallemand London ESB",
+            "comment" : "whole in database",
+            "link" : "https://www.lallemandbrewing.com/en/canada/product-details/london-esb-english-style-ale-yeast/"
+        },
+        {
+            "alias" : "WLP860",
+            "comment" : "whole in database",
+            "link" : "https://www.whitelabs.com/yeast-single?id=230&type=YEAST"
+        }
+    ]
+}


### PR DESCRIPTION
This PR fixes some of the issues we had while retrieving and parsing hop and yeast data from the website.
Yeasts links and cross-referencing now works much better, as well as both models were improved to carry null objects, in case none was found while parsing.

This happens because the original dataset is a bit scarce as some data are missing, but not consistently across the whole dataset. 
Detecting those (with null objects for instance) makes it easier later on to create reports for anyone to improve the database.